### PR TITLE
Switch to CommonJS for maximum compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ imported to begin:
 import verifyTruepicWebhook from '@truepic/webhook-verifier'
 ```
 
+CommonJS is also supported:
+
+```js
+const verifyTruepicWebhook = require('@truepic/webhook-verifier')
+```
+
 This `verifyTruepicWebhook` function (or whatever you imported it as) is then
 called with the following arguments:
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,12 +1,13 @@
-import js from '@eslint/js'
-import prettier from 'eslint-config-prettier'
-import node from 'eslint-plugin-n'
-import globals from 'globals'
+const js = require('@eslint/js')
+const prettier = require('eslint-config-prettier')
+const node = require('eslint-plugin-n')
+const globals = require('globals')
 
-export default [
+module.exports = [
   {
     languageOptions: {
       globals: { ...globals.node },
+      sourceType: 'commonjs',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@truepic/webhook-verifier",
   "version": "1.4.0",
-  "type": "module",
   "description": "Verify webhooks from Truepic Vision or Lens in your Node.js app",
   "homepage": "https://github.com/TRUEPIC/webhook-verifier-nodejs#readme",
   "bugs": "https://github.com/TRUEPIC/webhook-verifier-nodejs/issues",

--- a/src/error.js
+++ b/src/error.js
@@ -19,4 +19,4 @@ class TruepicWebhookVerifierError extends Error {
   }
 }
 
-export default TruepicWebhookVerifierError
+module.exports = TruepicWebhookVerifierError

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
-import { createHmac, timingSafeEqual } from 'node:crypto'
-import TruepicWebhookVerifierError from './error.js'
+const { createHmac, timingSafeEqual } = require('node:crypto')
+const TruepicWebhookVerifierError = require('./error')
 
 /**
  * Parse the `truepic-signature` header into timestamp and signature values.
@@ -164,5 +164,5 @@ function verifyTruepicWebhook({
 }
 
 /** @module @truepic/webhook-verifier */
-export default verifyTruepicWebhook
-export { TruepicWebhookVerifierError }
+module.exports = verifyTruepicWebhook
+module.exports.TruepicWebhookVerifierError = TruepicWebhookVerifierError

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -1,6 +1,8 @@
-import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
-import verifyTruepicWebhook, { TruepicWebhookVerifierError } from './main.js'
+const assert = require('node:assert/strict')
+const { describe, it } = require('node:test')
+const verifyTruepicWebhook = require('./main')
+
+const { TruepicWebhookVerifierError } = verifyTruepicWebhook
 
 describe('verifyTruepicWebhook', () => {
   // Successful values.


### PR DESCRIPTION
Importing via ESM continues to work the same, so this is not a backwards-incompatible change.