### PR TITLE
Throw TruepicWebhookVerifierError for malformed signatures

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -101,8 +101,8 @@ function verifyTimestamp({ timestamp, leewayMinutes }) {
  * @returns {true} If verification succeeds.
  */
 function verifySignature({ url, secret, body, timestamp, signature }) {
-  // Rebuild the signature (SHA-256, base64-encoded HMAC digest) with a secret
-  // that only Truepic and the intended receiver are privy to.
+  // Rebuild the signature (SHA-256 HMAC digest) with a secret that only Truepic
+  // and the intended receiver are privy to.
   const comparisonSignature = createHmac('sha256', secret)
 
   // Concatenate the full URL that received the request, timestamp parsed from
@@ -112,11 +112,14 @@ function verifySignature({ url, secret, body, timestamp, signature }) {
   // ways, which can result in a different signature.
   comparisonSignature.update([url, timestamp, body].join(','))
 
-  // Compare with a constant-time algorithm to prevent a timing attack.
-  const isEqual = timingSafeEqual(
-    Buffer.from(comparisonSignature.digest('base64'), 'base64'),
-    Buffer.from(signature, 'base64'),
-  )
+  const comparisonBuffer = comparisonSignature.digest()
+  const signatureBuffer = Buffer.from(signature, 'base64')
+
+  // Compare with a constant-time algorithm to prevent a timing attack. It
+  // requires equal-length buffers, otherwise it throws an error.
+  const isEqual =
+    comparisonBuffer.length === signatureBuffer.length &&
+    timingSafeEqual(comparisonBuffer, signatureBuffer)
 
   if (!isEqual) {
     throw new TruepicWebhookVerifierError('Signature is not valid')

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -199,6 +199,20 @@ describe('verifyTruepicWebhook', () => {
       )
     })
 
+    it('if the `header` signature decodes to the wrong length', () => {
+      assert.throws(
+        () =>
+          verifyTruepicWebhook({
+            url,
+            secret,
+            header: 't=1698259719,s=Zm9v',
+            body,
+            leewayMinutes,
+          }),
+        new TruepicWebhookVerifierError('Signature is not valid'),
+      )
+    })
+
     it('if the `secret` is not what was used to sign', () => {
       assert.throws(
         () =>


### PR DESCRIPTION
## Summary

- `timingSafeEqual` throws `RangeError` when its inputs differ in length, so any signature that didn't base64-decode to 32 bytes (e.g. `s=Zm9v`, garbage, truncated) leaked a `RangeError` out of the verifier instead of the documented `TruepicWebhookVerifierError`. Pre-empt the length check so the public contract holds.
- Drop the redundant `digest('base64')` → `Buffer.from(…, 'base64')` round-trip in favor of `digest()` returning raw bytes directly.
- Add a regression test covering the malformed-signature case.

## Test plan

- [x] `npm test` — 15/15 pass, including the new `if the header signature decodes to the wrong length` case.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)