### PR TITLE
Strict-parse the truepic-signature header

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,39 +21,46 @@ function parseHeader(header) {
     throw new TruepicWebhookVerifierError('Header is missing or empty')
   }
 
-  // Split the the header value on the comma (`,`). This should leave two parts:
+  // Split the header value on the comma (`,`). This must leave exactly two
+  // non-empty parts:
   //     - t=1634066973
   //     - s=6FBEiVZ8EO79dk5XllfnG18b83ZvLt2kdxcE8FJ/BwU
-  const [timestampParts, signatureParts] = header.split(',')
+  const parts = header.split(',')
 
-  if (!timestampParts?.length || !signatureParts?.length) {
+  if (parts.length !== 2 || !parts[0].length || !parts[1].length) {
     throw new TruepicWebhookVerifierError(
       'Header cannot be parsed into timestamp and signature',
     )
   }
 
-  // Split the timestamp (`t`) on the equals (`=`). This should leave two parts:
-  //    - t
-  //    - 1634066973
-  let [t, timestamp] = timestampParts.split('=')
+  const [timestampPart, signaturePart] = parts
 
-  if (t !== 't' || !timestamp?.length) {
+  // Split the timestamp (`t`) on the first equals (`=`). Splitting on every `=`
+  // would risk dropping characters from the value if it ever contained one
+  // (the timestamp itself never does, but the signature can — see below).
+  const tEq = timestampPart.indexOf('=')
+  const t = tEq === -1 ? timestampPart : timestampPart.slice(0, tEq)
+  const rawTimestamp = tEq === -1 ? '' : timestampPart.slice(tEq + 1)
+
+  if (t !== 't' || !rawTimestamp.length) {
     throw new TruepicWebhookVerifierError('Timestamp is missing or empty')
   }
 
   // Cast and verify that the timestamp value is a number.
-  timestamp = Number(timestamp)
+  const timestamp = Number(rawTimestamp)
 
   if (isNaN(timestamp)) {
     throw new TruepicWebhookVerifierError('Timestamp is not a number')
   }
 
-  // Split the signature (`s`) on the equals (`=`). This should leave two parts:
-  //    - s
-  //    - 6FBEiVZ8EO79dk5XllfnG18b83ZvLt2kdxcE8FJ/BwU
-  const [s, signature] = signatureParts.split('=')
+  // Split the signature (`s`) on the first equals (`=`). The signature value is
+  // base64 and can end in one or two `=` padding characters, which would
+  // otherwise be silently dropped.
+  const sEq = signaturePart.indexOf('=')
+  const s = sEq === -1 ? signaturePart : signaturePart.slice(0, sEq)
+  const signature = sEq === -1 ? '' : signaturePart.slice(sEq + 1)
 
-  if (s !== 's' || !signature?.length) {
+  if (s !== 's' || !signature.length) {
     throw new TruepicWebhookVerifierError('Signature is missing or empty')
   }
 

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -71,6 +71,22 @@ describe('verifyTruepicWebhook', () => {
       )
     })
 
+    it('if the `header` has more than two comma-separated parts', () => {
+      assert.throws(
+        () =>
+          verifyTruepicWebhook({
+            url,
+            secret,
+            header: 't=1698259719,s=abc,extra=stuff',
+            body,
+            leewayMinutes,
+          }),
+        new TruepicWebhookVerifierError(
+          'Header cannot be parsed into timestamp and signature',
+        ),
+      )
+    })
+
     it('if the `header` is missing the timestamp (`t`)', () => {
       assert.throws(
         () =>


### PR DESCRIPTION
## Summary

- Reject headers with anything other than two non-empty comma-separated parts. The previous parser destructured the first two elements and silently dropped anything past the second comma (`t=1,s=abc,extra` was accepted).
- Split each `k=v` pair on the *first* `=` only. Base64 signatures can end with `=` padding, and `String.prototype.split('=')` followed by 2-element destructuring was silently truncating that padding. It worked in practice because Node's base64 decoder is lenient, but the parser was dropping bytes from its input.
- Add a regression test for the multi-part comma case.

## Test plan

- [x] `npm test` — 16/16 pass.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)